### PR TITLE
updated to bypass ddos-guard

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,47 +2,54 @@ const axios = require('axios')
 const qs = require('qs')
 const cheerio = require('cheerio')
 const functions = require('@google-cloud/functions-framework')
+var ddos = require("@db8bot/ddosguard-bypass")
 
 functions.http('sepaperPOST', (req, resApp) => {
+    ddos.bypass("https://sci-hub.se", function (err, resp) {
+        if (err) {
+            console.log("error getting cookies", err);
+        } else {
+            let query = req.body.query
+            // let query = 'https://doi.org/10.1515/sem-2017-0088'
 
-    let query = req.body.query
-    // let query = 'https://doi.org/10.1515/sem-2017-0088'
-
-    let normalHeaders = {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Cache-Control': 'no-cache',
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive',
-        'Host': `sci-hub.se`,
-        'Referer': `https://sci-hub.se/`,
-        'Origin': `https://sci-hub.se`
-    }
+            let normalHeaders = {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Cache-Control': 'no-cache',
+                'User-Agent': resp["headers"]["user-agent"],
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+                'Accept-Encoding': 'gzip, deflate, br',
+                'Connection': 'keep-alive',
+                'Host': `sci-hub.se`,
+                'Referer': resp["headers"]["referer"],
+                'Origin': `https://sci-hub.se`,
+                'Cookie': resp["cookies"]["string"]
+            }
 
 
-    axios({
-        method: 'POST',
-        url: `https://sci-hub.se`,
-        data: qs.stringify({ 'request': query }),
-        headers: normalHeaders
-    }).then(async (res) => {
-        let $ = cheerio.load(res.data)
-        var matching;
-        try {
-            matching = $($('#article').children('embed')[0]).attr('src') || $($('#article').children('iframe')[0]).attr('src')
-            if (!matching.includes('https://') && matching.includes('http://')) matching = matching.replace('http://', 'https://')
-            if (!matching.includes('https://') && !matching.includes('http://') && matching.includes('//')) matching = matching.replace('//', 'https://')
-            if (matching.indexOf('/') === 0 && !matching.includes('//') && !matching.includes('sci-hub.se')) matching = `https://sci-hub.se${matching}`
+            axios({
+                method: 'POST',
+                url: `https://sci-hub.se`,
+                data: qs.stringify({ 'request': query }),
+                headers: normalHeaders
+            }).then(async (res) => {
+                let $ = cheerio.load(res.data)
+                var matching;
+                try {
+                    matching = $($('#article').children('embed')[0]).attr('src') || $($('#article').children('iframe')[0]).attr('src')
+                    if (!matching.includes('https://') && matching.includes('http://')) matching = matching.replace('http://', 'https://')
+                    if (!matching.includes('https://') && !matching.includes('http://') && matching.includes('//')) matching = matching.replace('//', 'https://')
+                    if (matching.indexOf('/') === 0 && !matching.includes('//') && !matching.includes('sci-hub.se')) matching = `https://sci-hub.se${matching}`
 
-            if (matching) resApp.status(200).send(matching)
-            // if (matching) console.log(matching)
-        } catch (e) {
-            resApp.sendStatus(404)
-            // console.log('no')
-            return
+                    if (matching) resApp.status(200).send(matching)
+                    // if (matching) console.log(matching)
+                } catch (e) {
+                    resApp.sendStatus(404)
+                    // console.log('no')
+                    return
+                }
+            }).catch(err => {
+                console.log(err)
+            })
         }
-    }).catch(err => {
-        console.log(err)
-    })
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@db8bot/ddosguard-bypass": "^1.0.0",
         "@google-cloud/functions-framework": "^3.1.2",
         "axios": "^0.27.2",
         "cheerio": "^1.0.0-rc.11",
@@ -45,6 +46,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@db8bot/ddosguard-bypass": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@db8bot/ddosguard-bypass/-/ddosguard-bypass-1.0.0.tgz",
+      "integrity": "sha512-4jCaVwmnmJVABa9DPixcCKI19l9mdx6+koYqWrckv50uZnjE2iEC4n74jkZnpqHCpKPnN7lxIoCph+iDuHqmrA==",
+      "dependencies": {
+        "axios": "^0.27.2",
+        "random-ua": "^0.0.6",
+        "set-cookie-parser": "^2.5.0"
       }
     },
     "node_modules/@google-cloud/functions-framework": {
@@ -1497,6 +1508,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/random-ua": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/random-ua/-/random-ua-0.0.6.tgz",
+      "integrity": "sha512-tn+qQ4vcvLdnkJqs8eGAcX4VW4ffL4vqXTu3+EbXucYo9qGjET06SxB1+CTGYZBWqc79QnJy1/omSmgtPGGgNA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1676,6 +1695,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz",
+      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1950,6 +1974,16 @@
         "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@db8bot/ddosguard-bypass": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@db8bot/ddosguard-bypass/-/ddosguard-bypass-1.0.0.tgz",
+      "integrity": "sha512-4jCaVwmnmJVABa9DPixcCKI19l9mdx6+koYqWrckv50uZnjE2iEC4n74jkZnpqHCpKPnN7lxIoCph+iDuHqmrA==",
+      "requires": {
+        "axios": "^0.27.2",
+        "random-ua": "^0.0.6",
+        "set-cookie-parser": "^2.5.0"
       }
     },
     "@google-cloud/functions-framework": {
@@ -3000,6 +3034,11 @@
         "side-channel": "^1.0.4"
       }
     },
+    "random-ua": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/random-ua/-/random-ua-0.0.6.tgz",
+      "integrity": "sha512-tn+qQ4vcvLdnkJqs8eGAcX4VW4ffL4vqXTu3+EbXucYo9qGjET06SxB1+CTGYZBWqc79QnJy1/omSmgtPGGgNA=="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3124,6 +3163,11 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz",
+      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w=="
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/db8bot/Occulation-CloudFunction#readme",
   "dependencies": {
+    "@db8bot/ddosguard-bypass": "^1.0.0",
     "@google-cloud/functions-framework": "^3.1.2",
     "axios": "^0.27.2",
     "cheerio": "^1.0.0-rc.11",


### PR DESCRIPTION
Now able to bypass ddos-guard without dependence on variable IP - rewritten pkg here: https://www.npmjs.com/package/@db8bot/ddosguard-bypass

while this practically makes this cloudfunction useless (since the scihub se stuff can just be moved to the bot compute for lower latency) this cf will stay up in case anyone wants to use it. first 2 million requests are free. 

It will get shutdown if it starts to incur costs.